### PR TITLE
Skips polars DB test on 3.12

### DIFF
--- a/tests/plugins/test_polars_extensions.py
+++ b/tests/plugins/test_polars_extensions.py
@@ -1,8 +1,9 @@
 import pathlib
+import sys
 
-import polars as pl
 import pytest
 
+import polars as pl
 from hamilton.plugins.polars_extensions import (
     PolarsAvroReader,
     PolarsAvroWriter,
@@ -119,6 +120,7 @@ def test_polars_avro(df: pl.DataFrame, tmp_path: pathlib.Path) -> None:
     assert df.frame_equal(df2)
 
 
+@pytest.mark.skipif(sys.version_info == (3, 12), reason="weird connectorx error on 3.12")
 def test_polars_database(df: pl.DataFrame, tmp_path: pathlib.Path) -> None:
     conn = f"sqlite:///{tmp_path}/test.db"
     table_name = "test_table"


### PR DESCRIPTION
Why? It complains about connectorx not being installed. But it is! and this only happens on python 3.12. Since python 3.12 is so new, likely something has changed in polars or connectorx. So skipping test for now on 3.12.


## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
